### PR TITLE
Phase 5.1: Switch session isolation to READ COMMITTED

### DIFF
--- a/app/database/session.py
+++ b/app/database/session.py
@@ -8,7 +8,10 @@ import sqlalchemy.orm
 import app.config as config
 
 
-engine = sqlalchemy.create_engine(config.settings.database_url)
+engine = sqlalchemy.create_engine(
+    config.settings.database_url,
+    isolation_level="READ COMMITTED",
+)
 
 SessionLocal = sqlalchemy.orm.sessionmaker(autocommit=False, autoflush=False, bind=engine)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -583,6 +583,7 @@ Type-safe, validated at startup. A missing or malformed `DATABASE_URL` causes an
 | Domain vs ORM models | Separate | Prevents ORM session state from leaking into business logic |
 | API schemas → domain inputs | Mapped at application boundary | Keeps domain layer free of FastAPI/Pydantic transport concerns |
 | Background task session | Own `SessionLocal` | Separate unit of work from the request transaction |
+| Session isolation level | `READ COMMITTED` | Each query sees the latest committed data; cross-session writes (e.g. background task) are immediately visible to open test sessions, removing the need for fresh-session workarounds in tests |
 | DB for tests | Real MySQL + transaction rollback | Integration tests verify real SQL behaviour, fast cleanup |
 | Error handling | Domain exceptions → HTTP codes | Keeps domain framework-agnostic |
 | Deployment | Monolithic Docker Compose | Single codebase, two containers, zero external dependencies |

--- a/docs/project_decisions.md
+++ b/docs/project_decisions.md
@@ -271,6 +271,21 @@ Implementation direction:
 - the background task should open and manage its own database session
 - treat notification logging as a separate unit of work from the synchronous booking creation flow
 
+## Session Isolation Level
+
+We configure all SQLAlchemy engines (application and test) to use `READ COMMITTED`.
+
+MySQL's default is `REPEATABLE READ`, which takes a transaction-wide snapshot on the first read. For short-lived CRUD transactions this makes no practical difference to correctness, but it creates a surprising testing inconvenience: a test session that is already open cannot see rows committed by `send_notification`'s separate session, requiring a new connection purely for assertion purposes.
+
+`READ COMMITTED` removes that friction: each SQL statement sees the latest committed data, so an open test session can query rows committed by the background task's session without any extra connection ceremony. It also matches the isolation behaviour that most developers expect by default.
+
+No correctness regression is introduced. The booking service does not rely on repeatable-read snapshot consistency — its transactions are short and do not re-read the same rows mid-transaction.
+
+Applied in:
+
+- `app/database/session.py` — `create_engine(..., isolation_level="READ COMMITTED")`
+- `tests/conftest.py` — same flag on the test engine
+
 ## Current Scope Principle
 
 When choosing between a simpler field and a normalized entity, we prefer the simpler field unless there is a clear business reason to model a standalone object.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,10 @@ def db_engine():
     alembic_cfg = alembic.config.Config("alembic.ini")
     alembic_cfg.set_main_option("sqlalchemy.url", config.settings.test_database_url)
     alembic.command.upgrade(alembic_cfg, "head")
-    engine = sqlalchemy.create_engine(config.settings.test_database_url)
+    engine = sqlalchemy.create_engine(
+        config.settings.test_database_url,
+        isolation_level="READ COMMITTED",
+    )
     yield engine
     engine.dispose()
     alembic.command.downgrade(alembic_cfg, "base")

--- a/tests/integration/test_create_notification_e2e.py
+++ b/tests/integration/test_create_notification_e2e.py
@@ -23,26 +23,6 @@ VALID_PAYLOAD = {
 }
 
 
-def _query_notification(db_engine, booking_id):
-    """
-    Open a fresh session to read notification rows committed by send_notification.
-
-    send_notification commits via its own session so a new session is required
-    to see the rows outside its transaction boundary.
-
-    :param db_engine: SQLAlchemy engine for the test database
-    :param booking_id: booking id to filter on
-    :return: list of NotificationLogORM rows
-    """
-    Session = sqlalchemy.orm.sessionmaker(bind=db_engine)
-    with Session() as fresh:
-        return (
-            fresh.query(db_models.NotificationLogORM)
-            .filter_by(booking_id=booking_id)
-            .all()
-        )
-
-
 class TestCreateBookingNotificationE2E:
     """End-to-end test for the POST /bookings → send_notification pipeline."""
 
@@ -51,6 +31,9 @@ class TestCreateBookingNotificationE2E:
         POST /bookings enqueues send_notification as a BackgroundTask; FastAPI's
         TestClient runs background tasks synchronously, so the notification_log
         row is committed before the response is received.
+
+        Under READ COMMITTED the open db_session sees the row committed by
+        send_notification's separate session without opening a new connection.
 
         This test does not mock send_notification — it exercises the full wiring
         from route → BackgroundTasks → send_notification → DB.
@@ -78,6 +61,6 @@ class TestCreateBookingNotificationE2E:
 
         assert response.status_code == 201
         booking_id = response.json()["id"]
-        rows = _query_notification(db_engine, booking_id)
+        rows = db_session.query(db_models.NotificationLogORM).filter_by(booking_id=booking_id).all()
         assert len(rows) == 1
         assert rows[0].event_type == "booking_created"

--- a/tests/integration/test_notifications.py
+++ b/tests/integration/test_notifications.py
@@ -39,40 +39,24 @@ BOOKING_CREATE = domain_models.BookingCreate(
 )
 
 
-def _query_notification(db_engine, booking_id):
-    """
-    Open a fresh session to read notification rows committed by send_notification.
-
-    send_notification commits via its own session.  The test's db_session runs
-    under REPEATABLE READ and cannot see those rows — a new session is required.
-
-    :param db_engine: SQLAlchemy engine for the test database
-    :param booking_id: booking id to filter on
-    :return: list of NotificationLogORM rows
-    """
-    Session = sqlalchemy.orm.sessionmaker(bind=db_engine)
-    with Session() as fresh:
-        return (
-            fresh.query(db_models.NotificationLogORM)
-            .filter_by(booking_id=booking_id)
-            .all()
-        )
-
-
 class TestSendNotification:
     """Tests for notifications.send_notification."""
 
-    def test_inserts_notification_log_row(self, db_session, db_engine):
+    def test_inserts_notification_log_row(self, db_session):
         """
         send_notification writes a notification_log row for the given booking id.
+
+        Under READ COMMITTED the open test session sees rows committed by
+        send_notification's separate session without needing a new connection.
 
         :return: None
         """
         booking = repository.BookingRepository(db_session).create(BOOKING_CREATE)
         notifications.send_notification(booking.id)
-        assert len(_query_notification(db_engine, booking.id)) == 1
+        rows = db_session.query(db_models.NotificationLogORM).filter_by(booking_id=booking.id).all()
+        assert len(rows) == 1
 
-    def test_sets_event_type_booking_created(self, db_session, db_engine):
+    def test_sets_event_type_booking_created(self, db_session):
         """
         The notification row carries event_type='booking_created'.
 
@@ -80,10 +64,10 @@ class TestSendNotification:
         """
         booking = repository.BookingRepository(db_session).create(BOOKING_CREATE)
         notifications.send_notification(booking.id)
-        row = _query_notification(db_engine, booking.id)[0]
+        row = db_session.query(db_models.NotificationLogORM).filter_by(booking_id=booking.id).one()
         assert row.event_type == "booking_created"
 
-    def test_message_references_booking_id(self, db_session, db_engine):
+    def test_message_references_booking_id(self, db_session):
         """
         The notification message contains the booking id.
 
@@ -91,7 +75,7 @@ class TestSendNotification:
         """
         booking = repository.BookingRepository(db_session).create(BOOKING_CREATE)
         notifications.send_notification(booking.id)
-        row = _query_notification(db_engine, booking.id)[0]
+        row = db_session.query(db_models.NotificationLogORM).filter_by(booking_id=booking.id).one()
         assert str(booking.id) in row.message
 
     def test_uses_own_session(self, db_session):


### PR DESCRIPTION
Closes #21

## Summary

- Set `isolation_level="READ COMMITTED"` on both the application engine (`app/database/session.py`) and the test engine (`tests/conftest.py`)
- Removed the `_query_notification` fresh-session workaround from `test_notifications.py` and `test_create_notification_e2e.py` — `db_session` now sees rows committed by `send_notification`'s separate session directly
- Updated `docs/architecture.md` (decision table) and `docs/project_decisions.md` (new section with rationale and tradeoffs)

## Why

MySQL's default `REPEATABLE READ` takes a transaction-wide snapshot on the first read. An open test session could not see rows committed by `send_notification`'s separate session, requiring a fresh connection purely for assertions. `READ COMMITTED` removes that friction without any correctness regression — the booking service does not re-read rows mid-transaction.

## Test plan

- [x] `make lint` passes
- [x] `make test` passes — 63/63 tests green
- [x] Notification tests simplified: no `_query_notification` helper, no `db_engine` fixture params where not needed
- [x] E2E test simplified: asserts via `db_session` directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)