### PR TITLE
Phase 6: Integration test suite for bookings API

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,11 +93,18 @@ transfer_booking_service/
 │   ├── unit/                       # Pure logic tests (no DB, no HTTP)
 │   │   ├── __init__.py
 │   │   └── test_booking_service.py
-│   ├── integration/                # Full-stack tests (HTTP → DB)
+│   ├── api/                        # HTTP endpoint tests (TestClient + real DB)
 │   │   ├── __init__.py
-│   │   ├── conftest.py             # Test DB setup, fixtures
-│   │   └── test_bookings_api.py
-│   └── conftest.py                 # Shared fixtures
+│   │   ├── conftest.py             # client fixture, autouse notification mock
+│   │   └── test_bookings.py        # Input validation, status codes, response shape
+│   ├── integration/                # Full-stack and repository-layer tests
+│   │   ├── __init__.py
+│   │   ├── conftest.py             # repo and client fixtures
+│   │   ├── test_bookings_api.py    # HTTP → domain → DB round-trip (8 named tests)
+│   │   ├── test_booking_repository.py  # Repository layer against real MySQL
+│   │   ├── test_notifications.py   # send_notification unit + DB assertions
+│   │   └── test_create_notification_e2e.py  # Full route → background task → DB
+│   └── conftest.py                 # Shared fixtures (db_engine, db_session)
 │
 ├── alembic.ini
 ├── docker-compose.yml
@@ -474,13 +481,15 @@ Test domain layer behaviour in isolation — no database, no HTTP, no I/O.
 | `test_invalid_status_transitions` | Disallowed transitions raise `InvalidStatusTransitionError` |
 | `test_create_booking_sets_pending` | New bookings always start as `pending` |
 
+### API tests (`tests/api/`)
+
+Test HTTP-layer concerns: status codes, response shape, input validation, and header behaviour. Use `TestClient` backed by the real test MySQL database (via `db_session` dependency override). `send_notification` is patched to a no-op via an `autouse` fixture so notification side-effects do not leak into HTTP-layer assertions.
+
 ### Integration tests (`tests/integration/`)
 
-Test the full request cycle: HTTP → route → service → repository → MySQL → response.
+Test the full request cycle and the repository layer against a real MySQL instance.
 
-Tests run against a real MySQL instance (from Docker Compose).
-
-**Isolation strategy:** Transaction rollback covers the main session (booking and booking_status_history writes), but it cannot reach the background task's independent `SessionLocal` commit. To prevent `notification_log` rows from leaking between tests and causing order-dependent failures, the notification writer is overridden with a no-op in the test fixture — either via FastAPI dependency override or by patching `integration.notifications.send_notification`. This keeps the rollback strategy intact and keeps integration tests focused on the HTTP → domain → DB flow rather than notification side-effects.
+**`test_bookings_api.py`** — HTTP → domain → DB round-trip. The 8 tests named in the original Phase 6 spec:
 
 | Test | What it validates |
 |------|-------------------|
@@ -492,6 +501,16 @@ Tests run against a real MySQL instance (from Docker Compose).
 | `test_invalid_transition_returns_422` | `completed → pending` returns 422 |
 | `test_get_nonexistent_booking_returns_404` | Proper error for missing resource |
 | `test_list_bookings_by_date` | Date filter returns correct subset |
+
+`send_notification` is suppressed with a module-scoped `autouse` fixture so notification writes do not affect booking assertions.
+
+**`test_booking_repository.py`** — `BookingRepository` directly against MySQL: create, get, update, timeline, history row counts.
+
+**`test_notifications.py`** — `send_notification` called directly; asserts `notification_log` row is written. `SessionLocal` is patched to the test engine.
+
+**`test_create_notification_e2e.py`** — Full wiring test: `POST /bookings` → `BackgroundTasks` → `send_notification` → DB row, no mocks anywhere.
+
+**Isolation strategy:** Row deletion after each test (`SET FOREIGN_KEY_CHECKS=0` + `DELETE` on all tables) keeps the schema intact while guaranteeing data isolation. `READ COMMITTED` isolation (set on all engines) ensures cross-session writes are visible immediately, eliminating fresh-connection workarounds in test assertions.
 
 ### Why this split matters
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,8 +1,11 @@
 """Pytest fixtures specific to integration tests."""
 
+import fastapi.testclient
 import pytest
 
+import app.api.dependencies as dependencies
 import app.database.repository as repository
+import app.main as main_app
 
 
 @pytest.fixture
@@ -14,3 +17,29 @@ def repo(db_session):
     :return: BookingRepository instance
     """
     return repository.BookingRepository(db_session)
+
+
+@pytest.fixture
+def client(db_session):
+    """
+    Provide a FastAPI TestClient with the ``get_db`` dependency overridden to
+    use the per-test database session.
+
+    Does not suppress send_notification — tests that need a no-op must apply
+    their own patch (e.g. test_bookings_api.py uses a file-scoped autouse fixture).
+
+    :param db_session: per-test SQLAlchemy session from the root conftest
+    :return: fastapi.testclient.TestClient bound to the test app
+    """
+    def override_get_db():
+        """
+        FastAPI dependency override that yields the test session.
+
+        :return: generator yielding the test db_session
+        """
+        yield db_session
+
+    main_app.app.dependency_overrides[dependencies.get_db] = override_get_db
+    with fastapi.testclient.TestClient(main_app.app) as c:
+        yield c
+    main_app.app.dependency_overrides.clear()

--- a/tests/integration/test_bookings_api.py
+++ b/tests/integration/test_bookings_api.py
@@ -1,0 +1,138 @@
+"""Integration tests for the bookings API — full HTTP → domain → DB round-trip.
+
+Uses a real MySQL test database brought to head via Alembic migrations.
+send_notification is suppressed with a no-op for the duration of this module
+so background-task writes do not leak into test assertions.
+"""
+
+import unittest.mock
+
+import pytest
+
+
+VALID_PAYLOAD = {
+    "passenger_name": "Alice Smith",
+    "flight_number": "BA123",
+    "pickup_time": "2025-06-01T10:00:00",
+    "pickup_location": "Heathrow T2",
+    "dropoff_location": "City Hotel",
+}
+
+
+@pytest.fixture(autouse=True)
+def suppress_send_notification():
+    """
+    Replace send_notification with a no-op for every test in this module.
+
+    The background task opens its own session and commits independently, which
+    would write notification_log rows that are visible to later assertions under
+    READ COMMITTED.  Suppressing it keeps each test focused on booking behaviour.
+
+    autouse=True scopes this to the module — it does not affect other integration
+    test modules that need send_notification to run for real.
+
+    :return: None
+    """
+    with unittest.mock.patch("app.integration.notifications.send_notification"):
+        yield
+
+
+class TestBookingsAPI:
+    """Full HTTP → domain → DB integration tests for the /bookings routes."""
+
+    def test_create_booking_returns_201(self, client):
+        """
+        POST /bookings with valid data persists the booking and returns 201 with
+        pending status and all expected fields.
+
+        :return: None
+        """
+        response = client.post("/bookings", json=VALID_PAYLOAD)
+        assert response.status_code == 201
+        data = response.json()
+        assert data["status"] == "pending"
+        assert data["passenger_name"] == VALID_PAYLOAD["passenger_name"]
+        assert data["flight_number"] == VALID_PAYLOAD["flight_number"]
+        assert "id" in data
+
+    def test_get_booking_by_id(self, client):
+        """
+        GET /bookings/{id} returns the persisted booking with correct data.
+
+        :return: None
+        """
+        created = client.post("/bookings", json=VALID_PAYLOAD).json()
+        response = client.get(f"/bookings/{created['id']}")
+        assert response.status_code == 200
+        assert response.json()["id"] == created["id"]
+        assert response.json()["passenger_name"] == VALID_PAYLOAD["passenger_name"]
+
+    def test_pending_to_confirmed(self, client):
+        """
+        PATCH /bookings/{id}/status transitions a pending booking to confirmed.
+
+        :return: None
+        """
+        booking_id = client.post("/bookings", json=VALID_PAYLOAD).json()["id"]
+        response = client.patch(f"/bookings/{booking_id}/status", json={"status": "confirmed"})
+        assert response.status_code == 200
+        assert response.json()["status"] == "confirmed"
+
+    def test_confirmed_to_completed(self, client):
+        """
+        PATCH /bookings/{id}/status transitions a confirmed booking to completed.
+
+        :return: None
+        """
+        booking_id = client.post("/bookings", json=VALID_PAYLOAD).json()["id"]
+        client.patch(f"/bookings/{booking_id}/status", json={"status": "confirmed"})
+        response = client.patch(f"/bookings/{booking_id}/status", json={"status": "completed"})
+        assert response.status_code == 200
+        assert response.json()["status"] == "completed"
+
+    def test_pending_to_cancelled(self, client):
+        """
+        PATCH /bookings/{id}/status cancels a pending booking directly.
+
+        :return: None
+        """
+        booking_id = client.post("/bookings", json=VALID_PAYLOAD).json()["id"]
+        response = client.patch(f"/bookings/{booking_id}/status", json={"status": "cancelled"})
+        assert response.status_code == 200
+        assert response.json()["status"] == "cancelled"
+
+    def test_invalid_transition_returns_422(self, client):
+        """
+        PATCH /bookings/{id}/status returns 422 for a disallowed transition
+        (completed → pending).
+
+        :return: None
+        """
+        booking_id = client.post("/bookings", json=VALID_PAYLOAD).json()["id"]
+        client.patch(f"/bookings/{booking_id}/status", json={"status": "confirmed"})
+        client.patch(f"/bookings/{booking_id}/status", json={"status": "completed"})
+        response = client.patch(f"/bookings/{booking_id}/status", json={"status": "pending"})
+        assert response.status_code == 422
+
+    def test_get_nonexistent_booking_returns_404(self, client):
+        """
+        GET /bookings/{id} returns 404 when the booking does not exist.
+
+        :return: None
+        """
+        response = client.get("/bookings/999999")
+        assert response.status_code == 404
+
+    def test_list_bookings_by_date(self, client):
+        """
+        GET /bookings?date=YYYY-MM-DD returns only bookings whose pickup_time
+        falls on that date.
+
+        :return: None
+        """
+        client.post("/bookings", json=VALID_PAYLOAD)
+        response = client.get("/bookings", params={"date": "2025-06-01"})
+        assert response.status_code == 200
+        results = response.json()
+        assert len(results) >= 1
+        assert all(r["pickup_time"].startswith("2025-06-01") for r in results)


### PR DESCRIPTION
Closes #6

## Summary

- Added `tests/integration/test_bookings_api.py` with the 8 tests named in issue #6, covering the full HTTP → domain → DB round-trip
- Added `client` fixture to `tests/integration/conftest.py` so integration tests share the existing `db_session`/`db_engine` infrastructure (Alembic-managed schema, real MySQL, row-deletion isolation)
- `send_notification` suppressed via a module-scoped `autouse` fixture in `test_bookings_api.py` — does not affect `test_notifications.py` or `test_create_notification_e2e.py`
- Updated `docs/architecture.md`: corrected directory tree to show actual `tests/api/` + `tests/integration/` layout; expanded testing strategy section to describe each module's role and isolation approach

## Alignment with issue comment

Per the comment on #6: schema is brought to head via `alembic upgrade head` (existing root conftest behaviour), real MySQL is used (not SQLite), and the notification writer is overridden with a no-op to prevent `notification_log` leakage.

## Test plan

- [x] `make lint` — all checks passed
- [x] `make test` — 71/71 tests green
- [x] `docker compose run --rm app pytest tests/integration/test_bookings_api.py` — 8/8 pass
- [x] All existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)