### PR TITLE
Phase 6.1: Reduce API vs integration test duplication

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -481,26 +481,34 @@ Test domain layer behaviour in isolation — no database, no HTTP, no I/O.
 | `test_invalid_status_transitions` | Disallowed transitions raise `InvalidStatusTransitionError` |
 | `test_create_booking_sets_pending` | New bookings always start as `pending` |
 
+### Responsibility boundary
+
+Each test suite has a distinct, non-overlapping purpose:
+
+| Suite | Owns | Does not duplicate |
+|-------|------|--------------------|
+| `tests/api/` | HTTP contract: status codes, response shape, input validation, exception mapping, notification enqueue | Multi-step state flows |
+| `tests/integration/test_bookings_api.py` | Multi-step flows that span several transitions and prove DB persistence end-to-end | HTTP contract details |
+| `tests/integration/test_booking_repository.py` | Repository layer against real MySQL | HTTP layer |
+| `tests/integration/test_notifications.py` | `send_notification` → `notification_log` row | HTTP layer |
+| `tests/integration/test_create_notification_e2e.py` | Full route → BackgroundTasks → DB, no mocks | Single-layer concerns |
+| `tests/unit/` | Domain business rules, no I/O | Everything else |
+
 ### API tests (`tests/api/`)
 
-Test HTTP-layer concerns: status codes, response shape, input validation, and header behaviour. Use `TestClient` backed by the real test MySQL database (via `db_session` dependency override). `send_notification` is patched to a no-op via an `autouse` fixture so notification side-effects do not leak into HTTP-layer assertions.
+Test HTTP-layer concerns: status codes, response shape, input validation, and exception mapping. Use `TestClient` backed by the real test MySQL database (via `db_session` dependency override). `send_notification` is patched to a no-op via an `autouse` fixture so notification side-effects do not affect HTTP-layer assertions.
 
 ### Integration tests (`tests/integration/`)
 
 Test the full request cycle and the repository layer against a real MySQL instance.
 
-**`test_bookings_api.py`** — HTTP → domain → DB round-trip. The 8 tests named in the original Phase 6 spec:
+**`test_bookings_api.py`** — Multi-step end-to-end flows not covered by the API suite:
 
 | Test | What it validates |
 |------|-------------------|
-| `test_create_booking_returns_201` | Full creation flow, response shape, default `pending` status |
-| `test_get_booking_by_id` | Retrieval returns correct data |
-| `test_pending_to_confirmed` | Valid transition works end-to-end |
-| `test_confirmed_to_completed` | Valid transition works end-to-end |
-| `test_pending_to_cancelled` | Valid business path exercises full stack |
-| `test_invalid_transition_returns_422` | `completed → pending` returns 422 |
-| `test_get_nonexistent_booking_returns_404` | Proper error for missing resource |
-| `test_list_bookings_by_date` | Date filter returns correct subset |
+| `test_full_booking_lifecycle` | Create then retrieve — anchors full DB wiring |
+| `test_confirmed_to_completed` | Two-step transition persisted correctly |
+| `test_pending_to_cancelled` | Single-step cancellation from pending |
 
 `send_notification` is suppressed with a module-scoped `autouse` fixture so notification writes do not affect booking assertions.
 

--- a/tests/integration/test_bookings_api.py
+++ b/tests/integration/test_bookings_api.py
@@ -1,8 +1,19 @@
-"""Integration tests for the bookings API — full HTTP → domain → DB round-trip.
+"""Integration tests for multi-step booking flows — full HTTP → domain → DB round-trip.
 
-Uses a real MySQL test database brought to head via Alembic migrations.
-send_notification is suppressed with a no-op for the duration of this module
-so background-task writes do not leak into test assertions.
+Responsibility boundary
+-----------------------
+tests/api/test_bookings.py  — HTTP contract: status codes, response shape,
+                              input validation, exception mapping, notification
+                              enqueue.  No duplicate happy-path flows here.
+
+tests/integration/test_bookings_api.py (this file) — end-to-end flows that
+                              span multiple state transitions and prove the
+                              full stack (route → service → repository → MySQL)
+                              works correctly for scenarios not covered by the
+                              API suite.
+
+send_notification is suppressed with a module-scoped autouse fixture so
+notification_log writes do not interfere with booking assertions.
 """
 
 import unittest.mock
@@ -24,12 +35,8 @@ def suppress_send_notification():
     """
     Replace send_notification with a no-op for every test in this module.
 
-    The background task opens its own session and commits independently, which
-    would write notification_log rows that are visible to later assertions under
-    READ COMMITTED.  Suppressing it keeps each test focused on booking behaviour.
-
-    autouse=True scopes this to the module — it does not affect other integration
-    test modules that need send_notification to run for real.
+    autouse=True scopes this to the module only — it does not affect other
+    integration test modules that need send_notification to run for real.
 
     :return: None
     """
@@ -38,49 +45,31 @@ def suppress_send_notification():
 
 
 class TestBookingsAPI:
-    """Full HTTP → domain → DB integration tests for the /bookings routes."""
+    """End-to-end booking flows that span multiple state transitions."""
 
-    def test_create_booking_returns_201(self, client):
+    def test_full_booking_lifecycle(self, client):
         """
-        POST /bookings with valid data persists the booking and returns 201 with
-        pending status and all expected fields.
+        A booking can be created and immediately retrieved with correct data.
+
+        Anchors the full DB wiring: route → service → repository → MySQL → response.
+        Complements the HTTP-contract tests in tests/api/ by verifying the
+        persisted state, not just the response shape.
 
         :return: None
         """
         response = client.post("/bookings", json=VALID_PAYLOAD)
         assert response.status_code == 201
-        data = response.json()
-        assert data["status"] == "pending"
-        assert data["passenger_name"] == VALID_PAYLOAD["passenger_name"]
-        assert data["flight_number"] == VALID_PAYLOAD["flight_number"]
-        assert "id" in data
+        booking_id = response.json()["id"]
 
-    def test_get_booking_by_id(self, client):
-        """
-        GET /bookings/{id} returns the persisted booking with correct data.
-
-        :return: None
-        """
-        created = client.post("/bookings", json=VALID_PAYLOAD).json()
-        response = client.get(f"/bookings/{created['id']}")
-        assert response.status_code == 200
-        assert response.json()["id"] == created["id"]
-        assert response.json()["passenger_name"] == VALID_PAYLOAD["passenger_name"]
-
-    def test_pending_to_confirmed(self, client):
-        """
-        PATCH /bookings/{id}/status transitions a pending booking to confirmed.
-
-        :return: None
-        """
-        booking_id = client.post("/bookings", json=VALID_PAYLOAD).json()["id"]
-        response = client.patch(f"/bookings/{booking_id}/status", json={"status": "confirmed"})
-        assert response.status_code == 200
-        assert response.json()["status"] == "confirmed"
+        get_response = client.get(f"/bookings/{booking_id}")
+        assert get_response.status_code == 200
+        assert get_response.json()["id"] == booking_id
+        assert get_response.json()["status"] == "pending"
 
     def test_confirmed_to_completed(self, client):
         """
-        PATCH /bookings/{id}/status transitions a confirmed booking to completed.
+        A booking can transition pending → confirmed → completed across two
+        separate PATCH requests, with the final state persisted correctly.
 
         :return: None
         """
@@ -92,7 +81,7 @@ class TestBookingsAPI:
 
     def test_pending_to_cancelled(self, client):
         """
-        PATCH /bookings/{id}/status cancels a pending booking directly.
+        A booking can be cancelled directly from pending in a single transition.
 
         :return: None
         """
@@ -100,39 +89,3 @@ class TestBookingsAPI:
         response = client.patch(f"/bookings/{booking_id}/status", json={"status": "cancelled"})
         assert response.status_code == 200
         assert response.json()["status"] == "cancelled"
-
-    def test_invalid_transition_returns_422(self, client):
-        """
-        PATCH /bookings/{id}/status returns 422 for a disallowed transition
-        (completed → pending).
-
-        :return: None
-        """
-        booking_id = client.post("/bookings", json=VALID_PAYLOAD).json()["id"]
-        client.patch(f"/bookings/{booking_id}/status", json={"status": "confirmed"})
-        client.patch(f"/bookings/{booking_id}/status", json={"status": "completed"})
-        response = client.patch(f"/bookings/{booking_id}/status", json={"status": "pending"})
-        assert response.status_code == 422
-
-    def test_get_nonexistent_booking_returns_404(self, client):
-        """
-        GET /bookings/{id} returns 404 when the booking does not exist.
-
-        :return: None
-        """
-        response = client.get("/bookings/999999")
-        assert response.status_code == 404
-
-    def test_list_bookings_by_date(self, client):
-        """
-        GET /bookings?date=YYYY-MM-DD returns only bookings whose pickup_time
-        falls on that date.
-
-        :return: None
-        """
-        client.post("/bookings", json=VALID_PAYLOAD)
-        response = client.get("/bookings", params={"date": "2025-06-01"})
-        assert response.status_code == 200
-        results = response.json()
-        assert len(results) >= 1
-        assert all(r["pickup_time"].startswith("2025-06-01") for r in results)


### PR DESCRIPTION
Closes #24

## Summary

Slimmed `tests/integration/test_bookings_api.py` from 8 tests to 3 by removing cases that duplicated HTTP-contract coverage already in `tests/api/test_bookings.py`.

**Removed** (covered by `tests/api/`):
- `test_create_booking_returns_201` — duplicates `test_returns_201` + `test_new_booking_status_is_pending`
- `test_get_booking_by_id` — duplicates `test_returns_200_for_existing_booking`
- `test_pending_to_confirmed` — duplicates `test_valid_transition_returns_200`
- `test_invalid_transition_returns_422` — exact duplicate
- `test_get_nonexistent_booking_returns_404` — duplicates `test_returns_404_for_missing_booking`
- `test_list_bookings_by_date` — duplicates `test_returns_bookings_on_given_date`

**Kept** (add genuine new confidence):
- `test_full_booking_lifecycle` — create then retrieve, anchors full DB wiring
- `test_confirmed_to_completed` — two-step transition not covered in API suite
- `test_pending_to_cancelled` — single-step cancellation not covered in API suite

Updated `docs/architecture.md` with a responsibility-boundary table documenting what each test module owns and why.

## Test plan

- [x] `make lint` — clean
- [x] `make test` — 66/66 green (down from 71 — the 5 removed tests were genuine duplicates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)