### PR TITLE
feat: add booking lookup by ID in the Reservations panel

### DIFF
--- a/frontend/src/components/BookingList.module.css
+++ b/frontend/src/components/BookingList.module.css
@@ -28,6 +28,36 @@
   opacity: 0.7;
 }
 
+.modeTabs {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.modeTab {
+  flex: 1;
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  padding: 0.45rem 0;
+  border-radius: var(--radius-sm);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: border-color var(--ease), color var(--ease), background var(--ease);
+}
+
+.modeTab:hover {
+  border-color: var(--border-hi);
+  color: var(--text);
+}
+
+.modeTabActive {
+  border-color: var(--gold);
+  color: var(--gold);
+  background: var(--gold-dim);
+}
+
 .searchRow {
   display: flex;
   gap: 0.75rem;

--- a/frontend/src/components/BookingList.tsx
+++ b/frontend/src/components/BookingList.tsx
@@ -8,13 +8,23 @@ interface Props {
   selectedId?: number
 }
 
+type Mode = 'date' | 'id'
+
 export default function BookingList({ onSelect, selectedId }: Props) {
+  const [mode, setMode] = useState<Mode>('date')
   const [date, setDate] = useState('')
+  const [bookingId, setBookingId] = useState('')
   const [bookings, setBookings] = useState<Booking[] | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const search = async (e: React.FormEvent) => {
+  const switchMode = (next: Mode) => {
+    setMode(next)
+    setBookings(null)
+    setError(null)
+  }
+
+  const searchByDate = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!date) return
     setLoading(true)
@@ -29,25 +39,75 @@ export default function BookingList({ onSelect, selectedId }: Props) {
     }
   }
 
+  const searchById = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const id = parseInt(bookingId, 10)
+    if (!id) return
+    setLoading(true)
+    setError(null)
+    setBookings(null)
+    try {
+      const booking = await api.getBooking(id)
+      onSelect(booking)
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Unexpected error')
+    } finally {
+      setLoading(false)
+    }
+  }
+
   return (
     <div className={styles.container}>
       <div className={styles.heading}>
         <span className={styles.ornament}>✦</span>
-        <h2>Bookings by Date</h2>
+        <h2>Find a Booking</h2>
         <span className={styles.ornament}>✦</span>
       </div>
 
-      <form className={styles.searchRow} onSubmit={search}>
-        <input
-          type="date"
-          value={date}
-          onChange={e => setDate(e.target.value)}
-          required
-        />
-        <button type="submit" disabled={loading}>
-          {loading ? '…' : 'Search'}
+      <div className={styles.modeTabs}>
+        <button
+          type="button"
+          className={`${styles.modeTab} ${mode === 'date' ? styles.modeTabActive : ''}`}
+          onClick={() => switchMode('date')}
+        >
+          By Date
         </button>
-      </form>
+        <button
+          type="button"
+          className={`${styles.modeTab} ${mode === 'id' ? styles.modeTabActive : ''}`}
+          onClick={() => switchMode('id')}
+        >
+          By ID
+        </button>
+      </div>
+
+      {mode === 'date' ? (
+        <form className={styles.searchRow} onSubmit={searchByDate}>
+          <input
+            type="date"
+            value={date}
+            onChange={e => setDate(e.target.value)}
+            required
+          />
+          <button type="submit" disabled={loading}>
+            {loading ? '…' : 'Search'}
+          </button>
+        </form>
+      ) : (
+        <form className={styles.searchRow} onSubmit={searchById}>
+          <input
+            type="number"
+            min="1"
+            placeholder="Booking ID"
+            value={bookingId}
+            onChange={e => setBookingId(e.target.value)}
+            required
+          />
+          <button type="submit" disabled={loading}>
+            {loading ? '…' : 'Find'}
+          </button>
+        </form>
+      )}
 
       {error && <p className={styles.error}>{error}</p>}
 


### PR DESCRIPTION
Closes #33

## Summary

Added a **By Date / By ID** mode toggle to `BookingList`. No new views, tabs, or routes — the existing `onSelect` callback handles navigation to `BookingDetails` in both cases.

**By Date** (existing behaviour, unchanged):
- Date picker → `GET /bookings?date=…` → scrollable list → click to open

**By ID** (new):
- Number input → `GET /bookings/{id}` → navigates directly to booking details
- 404 and other errors displayed inline below the form

Heading updated from "Bookings by Date" to "Find a Booking" to reflect both paths.

## Test plan

- [ ] `make build && make up && make migrate && make seed-demo`
- [ ] Reservations tab shows "By Date" / "By ID" toggle buttons
- [ ] By Date: search `2025-09-15` → lists Ellie Arroway and Duncan Idaho
- [ ] By ID: enter `3` → navigates directly to Naomi Nagata's booking
- [ ] By ID: enter `999999` → shows inline error "Booking 999999 not found"
- [ ] Switching mode clears previous results and errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)